### PR TITLE
Fixed the bug where the cfg variable was repeatedly declared, causing the authTpye configuration to fail.

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -135,7 +135,7 @@ func main() {
 	}
 
 	opts = []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg := &gnmi.Config{}
+	cfg = &gnmi.Config{}
 	cfg.Port = int64(*port)
 	cfg.UserAuth = userAuth
 	cfg.EnableTranslibWrite = bool(*gnmi_translib_write)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -135,7 +135,6 @@ func main() {
 	}
 
 	opts = []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}
-	cfg = &gnmi.Config{}
 	cfg.Port = int64(*port)
 	cfg.UserAuth = userAuth
 	cfg.EnableTranslibWrite = bool(*gnmi_translib_write)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
the cfg variable was repeatedly declared, causing the authTpye configuration to fail.
#### How I did it
The cfg variable was declared on line 62.
#### How to verify it
The cfg variable was declared on line 62.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

